### PR TITLE
Remove admin from user check

### DIFF
--- a/app/src/routes/api/v1/questionnaireRouter.js
+++ b/app/src/routes/api/v1/questionnaireRouter.js
@@ -72,7 +72,7 @@ class QuestionnaireRouter {
                     questions[question.childQuestions[j].name] = null;
                 }
             }
-        } 
+        }
         const answers = yield AnswerModel.find({
             questionnaire: this.params.id
         });
@@ -80,7 +80,7 @@ class QuestionnaireRouter {
         if (answers) {
             logger.debug('Data found!');
             let data = null;
-            
+
             for (let i = 0, length = answers.length; i < length; i++) {
                 const answer = answers[i];
                 const responses = Object.assign({}, questions);
@@ -96,7 +96,7 @@ class QuestionnaireRouter {
                 this.body.write(data);
             }
         }
-        this.body.end();    
+        this.body.end();
     }
 
 }
@@ -125,7 +125,7 @@ function * checkPermission(next) {
 }
 
 function* checkAdmin(next) {
-    if (!this.state.loggedUser || this.state.loggedUser.role !== 'ADMIN') {
+    if (!this.state.loggedUser) {
         this.throw(403, 'Not authorized');
         return;
     }

--- a/app/src/routes/api/v1/questionnaireRouter.js
+++ b/app/src/routes/api/v1/questionnaireRouter.js
@@ -74,7 +74,8 @@ class QuestionnaireRouter {
             }
         }
         const answers = yield AnswerModel.find({
-            questionnaire: this.params.id
+            questionnaire: this.params.id,
+            user: this.state.loggedUser.id
         });
         logger.debug('Obtaining data');
         if (answers) {


### PR DESCRIPTION
Simple change to remove the checking whether a user is an admin in the /download-answer endpoint of the Forest Watcher questionnaires API.