### PR TITLE
Feature/allow public reports

### DIFF
--- a/app/src/models/reportsModel.js
+++ b/app/src/models/reportsModel.js
@@ -35,6 +35,7 @@ var Report = new Schema({
     user: {type: ObjectId, required: true},
     languages: {type: Array, required: true, default: false},
     defaultLanguage: {type: String, required: true, trim: true},
+    public: {type: Boolean, required: true, default: false},
     createdAt: {type: Date, required: true, default: Date.now},
     questions: [ReportsQuestion]
 });

--- a/app/src/serializers/reportsSerializer.js
+++ b/app/src/serializers/reportsSerializer.js
@@ -8,7 +8,7 @@ var reportsSerializer = null;
 function createSerializer(languages) {
     return new JSONAPISerializer('reports', {
       attributes: [
-        'name', 'languages', 'defaultLanguage', 'areaOfInterest', 'user', 'questions', 'createdAt'
+        'name', 'languages', 'defaultLanguage', 'areaOfInterest', 'user', 'questions', 'createdAt', 'public'
       ],
       questions: {
           attributes: ['type', 'label', 'defaultValue', 'values', 'required']


### PR DESCRIPTION
Update to correct the filtering and validation of USERs vs ADMINs in the reports and answers end points. New field added to Reports Schema - Public (boolean). Now the endpoints return:

#Reports:
GET: Show all public & those created by user
GET/:id: Show only if public or created by user
POST: Available to all authenticated users
DELETE: Check user created the report before deletion

#Answers:
GET: ADMIN ? Show all answers to report : show only by user
GET:id: ADMIN ? Show answer : Check user is author before showing
POST: ADMIN ? Allow post : Check user is author of Report before posting
DELETE: Check user is author before deletion

All endpoint also now check whether user is author of report/answer and returns error if not.

TODO: enable checkPermissions() for POST when user flow is finalised.