### PR TITLE
Fix: allow required configurable on child questions

### DIFF
--- a/app/src/models/answersModel.js
+++ b/app/src/models/answersModel.js
@@ -10,7 +10,7 @@ var AnswerResponse = new Schema({
 
 var Answer = new Schema({
     report: {type: ObjectId, required: true},
-    areaOfInterest: {type: String, required: true, trim: true},
+    areaOfInterest: {type: String, required: false, trim: true},
     language: {type: String, required: true, trim: true},
     userPosition: {type: Array, required: false, default: []},
     clickedPosition: {type: Array, required: false, default: []},

--- a/app/src/models/reportsModel.js
+++ b/app/src/models/reportsModel.js
@@ -31,7 +31,7 @@ var ReportsQuestion = new Schema({
 
 var Report = new Schema({
     name: {type: Schema.Types.Mixed, required: true, default: {}},
-    areaOfInterest: {type: String, required: true, trim: true},
+    areaOfInterest: {type: String, required: false, trim: true},
     user: {type: ObjectId, required: true},
     languages: {type: Array, required: true, default: false},
     defaultLanguage: {type: String, required: true, trim: true},

--- a/app/src/routes/api/v1/answersRouter.js
+++ b/app/src/routes/api/v1/answersRouter.js
@@ -121,15 +121,15 @@ class AnswersRouter {
             if (question.childQuestions) {
                 for (let j = 0; j < question.childQuestions.length; j++) {
                     const childQuestion = question.childQuestions[j];
-                    let response = this.request.body.fields[childQuestion.name] || this.request.body.files[childQuestion.name];
-                    if (!response && question.required) {
+                    let childResponse = this.request.body.fields[childQuestion.name] || this.request.body.files[childQuestion.name];
+                    if (!childResponse && childQuestion.required && childQuestion.conditionalValue === response ) {
                         pushError(childQuestion);
                     }
                     if (question.type === 'blob') {
                         //upload file
-                        response = yield s3Service.uploadFile(response.path, response.name);
+                        childResponse = yield s3Service.uploadFile(response.path, response.name);
                     }
-                    pushResponse(childQuestion, response);
+                    pushResponse(childQuestion, childResponse);
                 }
             }
         }

--- a/app/src/routes/api/v1/answersRouter.js
+++ b/app/src/routes/api/v1/answersRouter.js
@@ -75,14 +75,24 @@ class AnswersRouter {
         logger.debug(this.request.body);
 
         const fields = this.request.body.fields;
+        let userPosition = [];
+        let clickedPosition = [];
+
+        try {
+            userPosition = fields.userPosition.split(',');
+            clickedPosition = fields.clickedPosition.split(',');
+        } catch(e) {
+            this.throw(400, `Position values must be separated by ','`);
+        }
 
         let answer = {
             report: this.params.reportId,
             areaOfInterest: fields.areaOfInterest,
             language: fields.language,
-            userPosition: fields.userPosition.split(','),
-            clickedPosition: fields.clickedPosition.split(','),
-            timeFrame: fields.timeFrame.split(','),
+            userPosition: userPosition,
+            clickedPosition: clickedPosition,
+            startTime: fields.startTime,
+            endTime: fields.endTime,
             layer: fields.layer,
             user: this.state.loggedUser.id,
             responses: []


### PR DESCRIPTION
When setting required to false on a parent, and required on a child question, an answer would be rejected by the API. Now the answer validation confirms whether the conditionalValue of the child is satisfied before rejecting response.

Other: disable required in the Schema for reports and answers to allow for generic reports.