### PR TITLE
Fix/validation for answers without questions

### DIFF
--- a/app/src/routes/api/v1/answersRouter.js
+++ b/app/src/routes/api/v1/answersRouter.js
@@ -112,7 +112,7 @@ class AnswersRouter {
 
         const questions = this.state.report.questions;
 
-        if (questions.length === 0) {
+        if (!questions.length) {
             this.throw(400, `No question associated with this report`);
         }
 

--- a/app/src/routes/api/v1/answersRouter.js
+++ b/app/src/routes/api/v1/answersRouter.js
@@ -208,6 +208,7 @@ function* checkExistReport(next) {
             { $or: [{public: true}, {user: new ObjectId(this.state.loggedUser.id)}] }
         ]
     }).populate('questions');
+    logger.info('REPORT FOUND: ');
     logger.info(report);
     if (!report) {
         this.throw(404, 'Report not found with these permissions');

--- a/app/src/validators/reportsValidator.js
+++ b/app/src/validators/reportsValidator.js
@@ -29,7 +29,7 @@ class ReportsValidator {
                 if (!question.label[lang]) {
                     pushError('name', `Question ${question.name}: label does not match language options`);
                 }
-                if (question.type === 'text') {
+                if (question.type === 'text' && question.defaultValue) {
                     if (!question.defaultValue[lang]) {
                         pushError('name', `Question ${question.name}: defaultValue does not match language options`);
                     }


### PR DESCRIPTION
Further updates to previous PR, allowing correct debugging of reports found on /POST to /answers, and fix for default value language validation on the reports POST end point.