### PR TITLE
Fix: set areaOfInterest to objectId in reports and answers models

### DIFF
--- a/app/src/models/answersModel.js
+++ b/app/src/models/answersModel.js
@@ -12,7 +12,7 @@ var Answer = new Schema({
     report: {type: ObjectId, required: true},
     username: {type: String, required: false, trim: true},
     organization: {type: String, required: false, trim: true},
-    areaOfInterest: {type: String, required: false, trim: true},
+    areaOfInterest: {type: ObjectId, required: false},
     language: {type: String, required: true, trim: true},
     userPosition: {type: Array, required: false, default: []},
     clickedPosition: {type: Array, required: false, default: []},

--- a/app/src/models/reportsModel.js
+++ b/app/src/models/reportsModel.js
@@ -31,7 +31,7 @@ var ReportsQuestion = new Schema({
 
 var Report = new Schema({
     name: {type: Schema.Types.Mixed, required: true, default: {}},
-    areaOfInterest: {type: String, required: false, trim: true},
+    areaOfInterest: {type: ObjectId, required: false},
     user: {type: ObjectId, required: true},
     languages: {type: Array, required: true, default: false},
     defaultLanguage: {type: String, required: true, trim: true},


### PR DESCRIPTION
Simple fix to update area of interest to an entity reference by id.