### PR TITLE
Feature/add report count to templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:6.2
+FROM mhart/alpine-node:8.1
 MAINTAINER raul.requero@vizzuality.com
 
 ENV NAME gfw-forms-api

--- a/app/src/models/reportsModel.js
+++ b/app/src/models/reportsModel.js
@@ -38,6 +38,7 @@ var Report = new Schema({
     public: {type: Boolean, required: true, default: false},
     createdAt: {type: Date, required: true, default: Date.now},
     answers: [{type: Schema.Types.ObjectId, ref: 'Answers'}],
+    status: {type: String, required: true, trim: true, default: 'draft'},
     questions: [ReportsQuestion]
 });
 

--- a/app/src/models/reportsModel.js
+++ b/app/src/models/reportsModel.js
@@ -37,7 +37,6 @@ var Report = new Schema({
     defaultLanguage: {type: String, required: true, trim: true},
     public: {type: Boolean, required: true, default: false},
     createdAt: {type: Date, required: true, default: Date.now},
-    answers: [{type: Schema.Types.ObjectId, ref: 'Answers'}],
     status: {type: String, required: true, trim: true, default: 'draft'},
     questions: [ReportsQuestion]
 });

--- a/app/src/models/reportsModel.js
+++ b/app/src/models/reportsModel.js
@@ -37,6 +37,7 @@ var Report = new Schema({
     defaultLanguage: {type: String, required: true, trim: true},
     public: {type: Boolean, required: true, default: false},
     createdAt: {type: Date, required: true, default: Date.now},
+    answers: [{type: Schema.Types.ObjectId, ref: 'Answers'}],
     questions: [ReportsQuestion]
 });
 

--- a/app/src/routes/api/v1/reportsRouter.js
+++ b/app/src/routes/api/v1/reportsRouter.js
@@ -30,6 +30,26 @@ class ReportsRouter {
             });
         }
         const reports = yield ReportsModel.find(filter);
+        
+        // get answer count for each report
+        const numReports = reports.length;
+        for (let i = 1; i < numReports; i++) {
+            let answersFilter = {};
+            if (this.state.loggedUser.role === 'ADMIN') {
+                answersFilter = {
+                    report: new ObjectId(reports[i].id)
+                };
+            } else {
+                answersFilter = {
+                    user: new ObjectId(this.state.loggedUser.id),
+                    report: new ObjectId(this.params.id)
+                };
+            }
+            const answers = yield AnswersModel.count(answersFilter);
+            logger.info(answers);
+            reports[i].answersCount = answers || 0;
+        }
+
         this.body = ReportsSerializer.serialize(reports);
     }
 
@@ -40,14 +60,13 @@ class ReportsRouter {
                 { _id: this.params.id },
                 { $or: [{public: true}, {user: new ObjectId(this.state.loggedUser.id)}] }
             ]
-        }).exec((err, report) => {
-            logger.info(report);
         });
         if (!report) {
             this.throw(404, 'Report not found with these permissions');
             return;
         }
 
+        // get answers count for the report
         let answersFilter = {};
         if (this.state.loggedUser.role === 'ADMIN') {
             answersFilter = {
@@ -59,9 +78,9 @@ class ReportsRouter {
                 report: new ObjectId(this.params.id)
             };
         }
-
         const answers = yield AnswersModel.count(answersFilter);
-        // logger.info(report);
+        report.answersCount = answers;
+        
         this.body = ReportsSerializer.serialize(report);
     }
 

--- a/app/src/serializers/reportsSerializer.js
+++ b/app/src/serializers/reportsSerializer.js
@@ -8,7 +8,7 @@ var reportsSerializer = null;
 function createSerializer(languages) {
     return new JSONAPISerializer('reports', {
       attributes: [
-        'name', 'languages', 'defaultLanguage', 'areaOfInterest', 'user', 'answerCount', 'questions', 'createdAt', 'public'
+        'name', 'languages', 'defaultLanguage', 'areaOfInterest', 'user', 'answerCount', 'questions', 'createdAt', 'public', 'status'
       ],
       questions: {
           attributes: ['type', 'label', 'defaultValue', 'values', 'required']

--- a/app/src/serializers/reportsSerializer.js
+++ b/app/src/serializers/reportsSerializer.js
@@ -8,7 +8,7 @@ var reportsSerializer = null;
 function createSerializer(languages) {
     return new JSONAPISerializer('reports', {
       attributes: [
-        'name', 'languages', 'defaultLanguage', 'areaOfInterest', 'user', 'questions', 'createdAt', 'public'
+        'name', 'languages', 'defaultLanguage', 'areaOfInterest', 'user', 'answerCount', 'questions', 'createdAt', 'public'
       ],
       questions: {
           attributes: ['type', 'label', 'defaultValue', 'values', 'required']

--- a/app/src/validators/reportsValidator.js
+++ b/app/src/validators/reportsValidator.js
@@ -8,6 +8,7 @@ class ReportsValidator {
         this.checkBody('name').notEmpty();
         this.checkBody('questions').notEmpty();
         this.checkBody('languages').notEmpty();
+        this.checkBody('status').notEmpty().isIn(['draft', 'published', 'unpublished']);
 
         if (this.errors) {
             this.body = ErrorSerializer.serializeValidationBodyErrors(this.errors);


### PR DESCRIPTION
Simple addition to the /reports and /reports/:reportId GET requests to included the count of answers submitted against the report.

An additional field has been added also to hold a status value of the report.