### PR TITLE
Feat: update contact us form

### DIFF
--- a/app/src/routes/api/v1/formRouter.js
+++ b/app/src/routes/api/v1/formRouter.js
@@ -41,17 +41,22 @@ class FormRouter {
     static * addFeedback() {
         logger.info('Sending mail');
         logger.debug('Data', this.request.body);
-        const {topic} = this.request.body;
+        const { topic, tool } = this.request.body;
         const mailParams = config.get('contactEmail');
+        const topicObj = mailParams.topics[topic || 'general-inquiry'];
+        const toolObj = mailParams.tools[tool || 'not-applicable'];
         const mailData = {
           user_email: this.request.body.email,
           message: this.request.body.message,
-          topic: mailParams.topics[topic].name,
-          opt_in: this.request.body.signup
+          topic: topicObj.name,
+          tool: toolObj.name,
+          opt_in: this.request.body.signup,
+          subject: `Contact form: ${topicObj.name} for ${toolObj.name}`
         };
         logger.debug('Mail data', mailData);
 
-        let wriRecipients = mailParams.topics[topic].emailTo.split(',');
+        const emails = mailParams.tools[tool];
+        let wriRecipients = emails.emailTo.split(',');
         wriRecipients = wriRecipients.map(function(mail) {
             return {
                 address: mail

--- a/app/src/routes/api/v1/formRouter.js
+++ b/app/src/routes/api/v1/formRouter.js
@@ -40,7 +40,6 @@ class FormRouter {
 
     static * addFeedback() {
         logger.info('Sending mail');
-        logger.debug('Data', this.request.body);
         const { topic, tool } = this.request.body;
         const mailParams = config.get('contactEmail');
         const topicObj = mailParams.topics[topic || 'general-inquiry'];

--- a/config/default.json
+++ b/config/default.json
@@ -25,41 +25,43 @@
         "template": "contact-form",
         "templateConfirm": "contact-form-confirmation",
         "topics": {
-            "report-a-bug-or-error-on-gfw": {
-                "name": "Report a bug or error on GFW",
-                "emailTo": "gfw@wri.org"
+            "report-a-bug-or-error": {
+                "name": "Report a bug or error"
             },
             "provide-feedback": {
-                "name": "Provide feedback",
-                "emailTo": "gfw@wri.org"
-            },
-            "media-request": {
-                "name": "Media request",
-                "emailTo": "gfwmedia@wri.org"
+                "name": "Provide feedback"
             },
             "data-related-inquiry": {
-                "name": "Data related inquiry",
-                "emailTo": "gfwdata@wri.org"
-            },
-            "gfw-commodities-inquiry": {
-                "name": "GFW Commodities inquiry",
-                "emailTo": "gfwcommodities@wri.org"
-            },
-            "gfw-fires-inquiry": {
-                "name": "GFW Fires inquiry",
-                "emailTo": "gfwfires@wri.org"
-            },
-            "gfw-climate-inquiry": {
-                "name": "GFW Climate inquiry",
-                "emailTo": "gfwclimate@wri.org"
-            },
-            "gfw-water-inquiry": {
-                "name": "GFW Water inquiry",
-                "emailTo": "GFWwater@wri.org"
+                "name": "Data related inquiry"
             },
             "general-inquiry": {
-                "name": "General inquiry",
-                "emailTo": "gfw@wri.org"
+                "name": "General inquiry"
+            }
+        },
+        "tools": {
+            "gfw": {
+                "name": "GFW",
+                "emailTo": "gfw2@wri.org"
+            },
+            "gfw-pro": {
+                "name": "GFW Pro",
+                "emailTo": "gfwprosupport@wri.org"
+            },
+            "fw": {
+                "name": "Forest Watcher",
+                "emailTo": "gfw2@wri.org"
+            },
+            "blog": {
+                "name": "GFW Blog",
+                "emailTo": "gfw2@wri.org"
+            },
+            "map-builder": {
+                "name": "GFW MapBuilder",
+                "emailTo": "gfw2@wri.org"
+            },
+            "not-applicable": {
+                "name": "Not applicable",
+                "emailTo": "gfw2@wri.org"
             }
         }
     },


### PR DESCRIPTION
As many of the platforms for GFW have been depreciated and email addresses have changed we need to update the contact form to reflect this.

- remove some fields from the topics options and remove email dep
- add new field called 'tool' which now dictates the email address to send to