### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@ RUN apk update && apk upgrade && \
 
 RUN addgroup $USER && adduser -s /bin/bash -D -G $USER $USER
 
-RUN yarn global add --unsafe-perm -g bunyan  grunt-cli
+RUN yarn global add grunt-cli bunyan
 
 RUN mkdir -p /opt/$NAME
 COPY package.json /opt/$NAME/package.json
+COPY yarn.lock /opt/$NAME/yarn.lock
 RUN cd /opt/$NAME && yarn
 
 COPY entrypoint.sh /opt/$NAME/entrypoint.sh
@@ -21,7 +22,7 @@ COPY config /opt/$NAME/config
 WORKDIR /opt/$NAME
 
 COPY ./app /opt/$NAME/app
-RUN chown $USER:$USER /opt/$NAME
+RUN chown -R $USER:$USER /opt/$NAME
 
 # Tell Docker we are going to use this ports
 EXPOSE 4400

--- a/base.yml
+++ b/base.yml
@@ -1,17 +1,16 @@
 base:
   build: .
   ports:
-    - "4400:4400"
+    - "4401:4401"
   environment:
-    PORT: 4400
+    PORT: 4401
     NODE_PATH: app/src
   container_name: gfw-forms-api
 mongo:
   image: mongo
   container_name: gfw-forms-mongo
-  command: --smallfiles
   ports:
-    - "27017"
+    - "27024:27017"
   volumes:
-    - $HOME/docker/data/gfw-forms-api:/data/db
+    - $HOME/docker/data/gfw-forms-api/mongodb:/data/db
   restart: always

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -1,33 +1,41 @@
-develop:
-  extends:
-    file: base.yml
-    service: base
-  ports:
-    - "35736:35729"
-  container_name: gfw-forms-develop
-  environment:
-    CT_REGISTER_MODE: auto
-    NODE_ENV: dev
-    QUEUE_URL: redis://mymachine:6379
-    QUEUE_PROVIDER: redis
-    QUEUE_NAME: mail
-    CT_URL: http://mymachine:9000
-    LOCAL_URL: http://mymachine:4400
-    WRI_MAIL_RECIPIENTS: <mails>
-    CT_TOKEN: token
-    GOOGLE_PRIVATE_KEY: <key>
-    GOOGLE_PROJECT_EMAIL: <mail>
-    TARGET_SHEET_ID: <sheet>
-    S3_ACCESS_KEY_ID: <key>
-    S3_SECRET_ACCESS_KEY: <key>
-    S3_BUCKET: <key>
-    FASTLY_ENABLED: "false"
-  command: develop
-  volumes:
-    - ./app:/opt/gfw-forms-api/app
-  links:
-    - mongo
-mongo:
-  extends:
-    file: base.yml
-    service: mongo
+version: "3"
+services:
+  develop:
+    build: .
+    ports:
+      - "4401:4401"
+    container_name: gfw-forms-develop
+    environment:
+      PORT: 4401
+      NODE_PATH: app/src
+      CT_REGISTER_MODE: auto
+      NODE_ENV: dev
+      QUEUE_URL: redis://mymachine:6379
+      QUEUE_PROVIDER: redis
+      QUEUE_NAME: mail
+      MONGO_PORT_27017_TCP_ADDR: mongo
+      REDIS_PORT_6379_TCP_ADDR: redis
+      CT_URL: http://mymachine:9000
+      LOCAL_URL: http://mymachine:4401
+      WRI_MAIL_RECIPIENTS: <mails>
+      CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
+      GOOGLE_PRIVATE_KEY: <key>
+      GOOGLE_PROJECT_EMAIL: <mail>
+      TARGET_SHEET_ID: <sheet>
+      S3_ACCESS_KEY_ID: <key>
+      S3_SECRET_ACCESS_KEY: <key>
+      S3_BUCKET: <key>
+      FASTLY_ENABLED: "false"
+    command: develop
+    volumes:
+      - ./app:/opt/gfw-forms-api/app
+    depends_on:
+      - mongo
+  mongo:
+    image: mongo:3.4
+    container_name: gfw-forms-mongo
+    ports:
+      - "27024:27017"
+    volumes:
+      - $HOME/docker/data/gfw-forms-api/mongodb:/data/db
+    restart: always


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Install bunyan and grunt-cli correctly, this was causing express to die
- Update port so it does not clash with another micro service
- Make mongo accessible externally
- Update docker-compose so version 3 is set